### PR TITLE
New feature: External apps can use "Location Share" to pick the current gps-location

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,10 +4,11 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "ca.cmetcalfe.locationshare"
+
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode 5
-        versionName "1.3.1"
+        versionCode 6
+        versionName "1.3.2"
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,27 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- pick geo from gps with all mimes (*/*) -->
+            <intent-filter android:label="@string/app_name_pick">
+                <action android:name="android.intent.action.PICK" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="geo" />
+            </intent-filter>
+
+            <!-- pick geo from gps for "geo:"  without mime -->
+            <intent-filter android:label="@string/app_name_pick">
+                <action android:name="android.intent.action.PICK" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="geo" />
+            </intent-filter>
         </activity>
         <activity android:name=".SettingsActivity"
             android:label="@string/settings" >

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -90,6 +90,16 @@
             android:onClick="viewLocation"
             android:text="@string/view_location" />
 
+        <!-- in geo picker mode there is a cancel button instead of share/copy/view where picking from gps can be canceled -->
+        <Button
+            android:id="@+id/cancelButton"
+            android:layout_width="0dp"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:visibility="gone"
+            android:onClick="onGeoPickCancel"
+            android:text="@android:string/cancel" />
+
     </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="app_name" translatable="false">Location Share</string>
 
+    <!-- the app title if the app is run as geo picker that is shown in the android choice chooser -->
+    <string name="app_name_pick" translatable="false">GPS (Location Share)</string>
+
     <string name="share_location">Share</string>
     <string name="copy_location">Copy</string>
     <string name="view_location">View</string>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
+// startParameter.offline=true
+
 include ':app'


### PR DESCRIPTION
Hello Carey.

I have added some code so that external apps can use "Location Share" to pick the current gps-location.

I need this feature when i [manually geo-tags to photos](https://github.com/k3b/APhotoManager/wiki/Howto-geotag-multible-photos) 

I have already done this for https://github.com/gjedeer/Acastus/issues/2 

It would be nice if you 

* merge this into your main repository 
* and create a new github-version-tag "v1.3.2" so it will be updated on f-droid app store,